### PR TITLE
Remove cpp11 import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,9 +13,8 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0.9000
+RoxygenNote: 7.1.1
 Imports:
-    cpp11,
     systemfonts (>= 0.3.0)
 LinkingTo: 
     cpp11,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,7 +3,6 @@
 export(get_font_features)
 export(shape_text)
 export(text_width)
-importFrom(cpp11,cpp_source)
 importFrom(systemfonts,match_font)
 importFrom(systemfonts,system_fonts)
 useDynLib(textshaping, .registration = TRUE)

--- a/R/textshaping-package.R
+++ b/R/textshaping-package.R
@@ -6,6 +6,5 @@
 ## usethis namespace: start
 #' @useDynLib textshaping, .registration = TRUE
 #' @importFrom systemfonts system_fonts
-#' @importFrom cpp11 cpp_source
 ## usethis namespace: end
 NULL


### PR DESCRIPTION
There is no need to import cpp11, it has no shared library like Rcpp, so
you only need it in LinkingTo.