### PR TITLE
Enable autobrew in CI when needed

### DIFF
--- a/configure
+++ b/configure
@@ -35,7 +35,7 @@ elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
   PKG_CFLAGS="${PKGCONFIG_CFLAGS}"
   PKG_LIBS="${PKGCONFIG_LIBS}"
 elif [ "`uname`" = "Darwin" ]; then
-  brew --version 2>/dev/null
+  test ! "$CI" && brew --version 2>/dev/null
   if [ $? -eq 0 ]; then
     BREWDIR="`brew --prefix`"
     PKG_CFLAGS="-I$BREWDIR/include/freetype2 -I$BREWDIR/include/harfbuzz -I$BREWDIR/include/glib-2.0  -I$BREWDIR/include/fribidi"


### PR DESCRIPTION
This will use the autobrew libs in CI setups on MacOS where the system libraries are missing.