### PR TITLE
fix typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@
 # textshaping 0.4.1
 
 * Make compiled code somewhat less assumptive about the correctness of the input
-* Fix a bug from too agressive early exiting shaping of strings with no max
+* Fix a bug from too aggressive early exiting shaping of strings with no max
   width (#45)
 * Fixed a mismatch between the default values of the `width` argument in
   `shape_text()` and `systemfonts::match_fonts()` (#44)

--- a/R/lorem_text.R
+++ b/R/lorem_text.R
@@ -10,7 +10,7 @@
 #' @param n The number of paragraphs to fetch. Each paragraph will be its own
 #' element in the returned character vector.
 #'
-#' @return a charactor vector of length `n`
+#' @return a character vector of length `n`
 #'
 #' @export
 #'

--- a/R/shape_text.R
+++ b/R/shape_text.R
@@ -280,7 +280,7 @@ shape_text <- function(
 #' This is a very simple alternative to [systemfonts::shape_string()] that
 #' simply calculates the width of strings without taking any newline into
 #' account. As such it is suitable to calculate the width of words or lines that
-#' has already been splitted by `\n`. Input is recycled to the length of
+#' have already been split by `\n`. Input is recycled to the length of
 #' `strings`.
 #'
 #' @inheritParams shape_text

--- a/man/lorem_text.Rd
+++ b/man/lorem_text.Rd
@@ -31,7 +31,7 @@ element in the returned character vector.}
 string}
 }
 \value{
-a charactor vector of length \code{n}
+a character vector of length \code{n}
 }
 \description{
 Textshaping exists partly to allow all the various scripts that exists in the

--- a/man/text_width.Rd
+++ b/man/text_width.Rd
@@ -62,7 +62,7 @@ provided \code{res} value to convert it into absolute values.
 This is a very simple alternative to \code{\link[systemfonts:shape_string]{systemfonts::shape_string()}} that
 simply calculates the width of strings without taking any newline into
 account. As such it is suitable to calculate the width of words or lines that
-has already been splitted by \verb{\\n}. Input is recycled to the length of
+have already been split by \verb{\\n}. Input is recycled to the length of
 \code{strings}.
 }
 \examples{

--- a/src/string_shape.cpp
+++ b/src/string_shape.cpp
@@ -68,7 +68,7 @@ bool HarfBuzzShaper::add_string(const char* string, FontSettings& font_info,
 
   unsigned int index = shape_infos.size();
 
-  // Add precalculated soft and hard breeak points to the sets
+  // Add precalculated soft and hard break points to the sets
   for (auto iter = soft_wrap.begin(); iter != soft_wrap.end(); ++iter) {
     soft_break.insert(run_start + (*iter) - 1);
   }
@@ -414,7 +414,7 @@ std::list<EmbedInfo> HarfBuzzShaper::combine_embeddings(std::vector<ShapeInfo>& 
 
   // Reverse ordering of consecutive embeddings in rtl
   // This is needed to keep their internal order during shaping
-  // Further collapses all consequtive runs into one embedding to simplify the final shapping operation
+  // Further collapses all consequtive runs into one embedding to simplify the final shaping operation
   auto run_start = all_embeddings.begin();
   int run_embed_level = run_start->embedding_level;
   std::list<EmbedInfo> final_embeddings;

--- a/src/string_shape.h
+++ b/src/string_shape.h
@@ -441,7 +441,7 @@ private:
     case 10: return true;    // Line feed
     case 11: return true;    // Vertical tab
     case 12: return true;    // Form feed
-    case 13: return true;    // Cariage return
+    case 13: return true;    // Carriage return
     case 133: return true;   // Next line
     case 8232: return true;  // Line Separator
     case 8233: return true;  // Paragraph Separator
@@ -483,7 +483,7 @@ private:
     case 10: return true;    // Line feed
     case 11: return true;    // Vertical tab
     case 12: return true;    // Form feed
-    case 13: return true;    // Cariage return
+    case 13: return true;    // Carriage return
     case 32: return true;    // Space
     case 133: return true;   // Next line
     case 5760: return true;  // Ogham Space Mark

--- a/vignettes/c_interface.Rmd
+++ b/vignettes/c_interface.Rmd
@@ -16,10 +16,10 @@ knitr::opts_chunk$set(
 ```
 
 textshaping is predominantly intended to be used by other packages implementing
-graphic devicees and calling it from the C level. As such it exports a set of
+graphic devices and calling it from the C level. As such it exports a set of
 functions that match the needs of graphic devices. The C API builds upon that of
 systemfonts and you'll thus need to link to both packages to access it 
-succesfully. This is done with the `LinkingTo` field in the `DESCRIPTION` file:
+successfully. This is done with the `LinkingTo` field in the `DESCRIPTION` file:
 
 ```
 LinkingTo: 


### PR DESCRIPTION
dumped repo strings exposed a few typos

only English language strings were checked

rephrased this

```
$ sed -n '280,284p' textshaping/R/shape_text.R
#' This is a very simple alternative to [systemfonts::shape_string()] that
#' simply calculates the width of strings without taking any newline into
#' account. As such it is suitable to calculate the width of words or lines that
#' has already been splitted by `\n`. Input is recycled to the length of
#' `strings`.
$ 
```