### PR TITLE
Use <cmath> for std::abs

### DIFF
--- a/src/string_shape.cpp
+++ b/src/string_shape.cpp
@@ -1,6 +1,7 @@
 #ifndef NO_HARFBUZZ_FRIBIDI
 
 #include <climits>
+#include <cmath> // for std::abs
 #include <iterator>
 #include <list>
 #include <vector>


### PR DESCRIPTION
This failed compilation for us, I guess different toolchains might wind up with `std::abs` not included if not done directly:

```
textshaping/src/string_shape.cpp:709:50: error: no member named 'abs' in namespace 'std'; did you mean simply 'abs'?
  709 |   shape_info.embeddings.back().embedding_level = std::abs(dir);
      |                                                  ^~~~~~~~
      |                                                  abs
```

https://cplusplus.com/reference/cmath/abs/